### PR TITLE
test(web): カバレッジ 100% の検証と未カバー箇所の修正

### DIFF
--- a/apps/web/src/components/ui/color-mode.test.tsx
+++ b/apps/web/src/components/ui/color-mode.test.tsx
@@ -1,18 +1,62 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { ColorModeProvider, useColorMode } from "./color-mode";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ColorModeButton,
+  ColorModeIcon,
+  ColorModeProvider,
+  DarkMode,
+  LightMode,
+  useColorMode,
+  useColorModeValue,
+} from "./color-mode";
+
+const mockSetTheme = vi.fn();
+const mockUseTheme = vi.fn(() => ({
+  resolvedTheme: "light" as string | undefined,
+  setTheme: mockSetTheme,
+  forcedTheme: undefined as string | undefined,
+}));
 
 vi.mock("next-themes", () => ({
   ThemeProvider: ({ children }: { children: ReactNode }) => (
     <div data-testid="theme-provider">{children}</div>
   ),
-  useTheme: () => ({
-    resolvedTheme: "light",
-    setTheme: vi.fn(),
-    forcedTheme: undefined,
-  }),
+  useTheme: () => mockUseTheme(),
 }));
+
+vi.mock("react-icons/lu", () => ({
+  LuMoon: () => <span data-testid="moon-icon" />,
+  LuSun: () => <span data-testid="sun-icon" />,
+}));
+
+vi.mock("@chakra-ui/react", () => ({
+  ClientOnly: ({ children }: { children: ReactNode }) => <>{children}</>,
+  IconButton: (props: Record<string, unknown>) => (
+    <button
+      type="button"
+      onClick={props.onClick as () => void}
+      aria-label={props["aria-label"] as string}
+    >
+      {props.children as ReactNode}
+    </button>
+  ),
+  Skeleton: () => <div data-testid="skeleton" />,
+  Span: (props: Record<string, unknown>) => (
+    <span className={props.className as string}>
+      {props.children as ReactNode}
+    </span>
+  ),
+}));
+
+beforeEach(() => {
+  mockSetTheme.mockClear();
+  mockUseTheme.mockReturnValue({
+    resolvedTheme: "light",
+    setTheme: mockSetTheme,
+    forcedTheme: undefined,
+  });
+});
 
 describe("ColorModeProvider", () => {
   it("renders children", () => {
@@ -25,14 +69,108 @@ describe("ColorModeProvider", () => {
   });
 });
 
-const TestConsumer = () => {
-  const { colorMode } = useColorMode();
-  return <span data-testid="color-mode">{colorMode}</span>;
-};
-
 describe("useColorMode", () => {
   it("returns the current color mode", () => {
-    render(<TestConsumer />);
-    expect(screen.getByTestId("color-mode").textContent).toBe("light");
+    const Consumer = () => {
+      const { colorMode } = useColorMode();
+      return <span data-testid="mode">{colorMode}</span>;
+    };
+    render(<Consumer />);
+    expect(screen.getByTestId("mode").textContent).toBe("light");
+  });
+
+  it("uses forcedTheme when present", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "light",
+      setTheme: mockSetTheme,
+      forcedTheme: "dark",
+    });
+    const Consumer = () => {
+      const { colorMode } = useColorMode();
+      return <span data-testid="mode">{colorMode}</span>;
+    };
+    render(<Consumer />);
+    expect(screen.getByTestId("mode").textContent).toBe("dark");
+  });
+
+  it("toggleColorMode switches from dark to light", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+      forcedTheme: undefined,
+    });
+    const Consumer = () => {
+      const { toggleColorMode } = useColorMode();
+      return (
+        <button type="button" onClick={toggleColorMode} data-testid="toggle" />
+      );
+    };
+    render(<Consumer />);
+    fireEvent.click(screen.getByTestId("toggle"));
+    expect(mockSetTheme).toHaveBeenCalledWith("light");
+  });
+});
+
+describe("useColorModeValue", () => {
+  it("returns light value in light mode", () => {
+    const Consumer = () => {
+      const val = useColorModeValue("light-val", "dark-val");
+      return <span data-testid="val">{val}</span>;
+    };
+    render(<Consumer />);
+    expect(screen.getByTestId("val").textContent).toBe("light-val");
+  });
+
+  it("returns dark value in dark mode", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+      forcedTheme: undefined,
+    });
+    const Consumer = () => {
+      const val = useColorModeValue("light-val", "dark-val");
+      return <span data-testid="val">{val}</span>;
+    };
+    render(<Consumer />);
+    expect(screen.getByTestId("val").textContent).toBe("dark-val");
+  });
+});
+
+describe("ColorModeIcon", () => {
+  it("renders sun icon in light mode", () => {
+    render(<ColorModeIcon />);
+    expect(screen.getByTestId("sun-icon")).toBeDefined();
+  });
+
+  it("renders moon icon in dark mode", () => {
+    mockUseTheme.mockReturnValue({
+      resolvedTheme: "dark",
+      setTheme: mockSetTheme,
+      forcedTheme: undefined,
+    });
+    render(<ColorModeIcon />);
+    expect(screen.getByTestId("moon-icon")).toBeDefined();
+  });
+});
+
+describe("ColorModeButton", () => {
+  it("renders and toggles color mode on click", () => {
+    render(<ColorModeButton />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+});
+
+describe("LightMode", () => {
+  it("renders children", () => {
+    render(<LightMode>content</LightMode>);
+    expect(screen.getByText("content")).toBeDefined();
+  });
+});
+
+describe("DarkMode", () => {
+  it("renders children", () => {
+    render(<DarkMode>content</DarkMode>);
+    expect(screen.getByText("content")).toBeDefined();
   });
 });

--- a/apps/web/src/emotion/emotion-client-ssr.test.tsx
+++ b/apps/web/src/emotion/emotion-client-ssr.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment node
 
 import type { EmotionCache } from "@emotion/cache";
-import { createElement } from "react";
 import { renderToString } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import { ClientCacheProvider, useInjectStyles } from "./emotion-client";
@@ -20,11 +19,13 @@ describe("emotion-client SSR", () => {
 
     const TestComponent = () => {
       useInjectStyles(mockCache);
-      return createElement("div", null, "ssr-test");
+      return <div data-testid="ssr-test">ssr-test</div>;
     };
 
     const html = renderToString(
-      createElement(ClientCacheProvider, null, createElement(TestComponent)),
+      <ClientCacheProvider>
+        <TestComponent />
+      </ClientCacheProvider>,
     );
 
     expect(html).toContain("ssr-test");

--- a/apps/web/src/emotion/emotion-client-ssr.test.tsx
+++ b/apps/web/src/emotion/emotion-client-ssr.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment node
+
+import type { EmotionCache } from "@emotion/cache";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { ClientCacheProvider, useInjectStyles } from "./emotion-client";
+
+describe("emotion-client SSR", () => {
+  it("useInjectStyles is a no-op in server environment", () => {
+    const mockFlush = vi.fn();
+    const mockCache = {
+      sheet: {
+        container: null,
+        tags: [],
+        flush: mockFlush,
+        _insertTag: vi.fn(),
+      },
+    } as unknown as EmotionCache;
+
+    const TestComponent = () => {
+      useInjectStyles(mockCache);
+      return createElement("div", null, "ssr-test");
+    };
+
+    const html = renderToString(
+      createElement(ClientCacheProvider, null, createElement(TestComponent)),
+    );
+
+    expect(html).toContain("ssr-test");
+    expect(mockFlush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/emotion/emotion-client.test.tsx
+++ b/apps/web/src/emotion/emotion-client.test.tsx
@@ -46,7 +46,8 @@ describe("useInjectStyles", () => {
 
     expect(screen.getByTestId("test")).toBeDefined();
     expect(mockCache.sheet.container).toBe(document.head);
-    expect(mockFlush).toHaveBeenCalled();
+    expect(mockFlush).toHaveBeenCalledTimes(1);
+    expect(mockInsertTag).toHaveBeenCalledTimes(1);
     expect(mockInsertTag).toHaveBeenCalledWith(mockTag);
   });
 });

--- a/apps/web/src/emotion/emotion-client.test.tsx
+++ b/apps/web/src/emotion/emotion-client.test.tsx
@@ -1,6 +1,8 @@
+import type { EmotionCache } from "@emotion/cache";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { ClientCacheProvider } from "./emotion-client";
+import { StrictMode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ClientCacheProvider, useInjectStyles } from "./emotion-client";
 
 describe("ClientCacheProvider", () => {
   it("renders children", () => {
@@ -11,5 +13,40 @@ describe("ClientCacheProvider", () => {
     );
     expect(screen.getByTestId("child")).toBeDefined();
     expect(screen.getByText("Hello")).toBeDefined();
+  });
+});
+
+describe("useInjectStyles", () => {
+  it("flushes cache and re-inserts tags on mount", () => {
+    const mockInsertTag = vi.fn();
+    const mockFlush = vi.fn();
+    const mockTag = document.createElement("style");
+
+    const mockCache = {
+      sheet: {
+        container: null as Node | null,
+        tags: [mockTag],
+        flush: mockFlush,
+        _insertTag: mockInsertTag,
+      },
+    } as unknown as EmotionCache;
+
+    const TestComponent = () => {
+      useInjectStyles(mockCache);
+      return <div data-testid="test">test</div>;
+    };
+
+    render(
+      <StrictMode>
+        <ClientCacheProvider>
+          <TestComponent />
+        </ClientCacheProvider>
+      </StrictMode>,
+    );
+
+    expect(screen.getByTestId("test")).toBeDefined();
+    expect(mockCache.sheet.container).toBe(document.head);
+    expect(mockFlush).toHaveBeenCalled();
+    expect(mockInsertTag).toHaveBeenCalledWith(mockTag);
   });
 });

--- a/apps/web/src/lib/supabase/server.test.ts
+++ b/apps/web/src/lib/supabase/server.test.ts
@@ -83,15 +83,15 @@ describe("createSupabaseServerClient", () => {
     vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
     vi.stubEnv("SUPABASE_ANON_KEY", "test-anon-key");
 
-    const request = new Request("http://localhost", {
-      headers: { Cookie: "a=1; b" },
-    });
-    createSupabaseServerClient(request);
-
     mockParseCookieHeader.mockReturnValueOnce([
       { name: "a", value: "1" },
       { name: "b", value: null },
     ]);
+
+    const request = new Request("http://localhost", {
+      headers: { Cookie: "a=1; b" },
+    });
+    createSupabaseServerClient(request);
 
     const cookies = capturedOptions?.cookies.getAll();
     expect(cookies).toEqual([{ name: "a", value: "1" }]);

--- a/apps/web/src/lib/supabase/server.test.ts
+++ b/apps/web/src/lib/supabase/server.test.ts
@@ -12,18 +12,22 @@ interface CookieOptions {
 
 let capturedOptions: CookieOptions | undefined;
 
+const mockParseCookieHeader = vi.fn(
+  (header: string): { name: string; value: string | null }[] => {
+    if (!header) return [];
+    return header.split("; ").map((pair) => {
+      const [name, ...rest] = pair.split("=");
+      return { name: name ?? "", value: rest.join("=") };
+    });
+  },
+);
+
 vi.mock("@supabase/ssr", () => ({
   createServerClient: (_url: string, _key: string, options: CookieOptions) => {
     capturedOptions = options;
     return { from: vi.fn() };
   },
-  parseCookieHeader: (header: string) => {
-    if (!header) return [];
-    return header.split("; ").map((pair) => {
-      const [name, ...rest] = pair.split("=");
-      return { name, value: rest.join("=") };
-    });
-  },
+  parseCookieHeader: (...args: [string]) => mockParseCookieHeader(...args),
   serializeCookieHeader: (name: string, value: string, _options: unknown) =>
     `${name}=${value}; Path=/`,
 }));
@@ -32,6 +36,7 @@ describe("createSupabaseServerClient", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     capturedOptions = undefined;
+    mockParseCookieHeader.mockClear();
   });
 
   it("returns { supabase, headers } when env vars are set", () => {
@@ -72,6 +77,24 @@ describe("createSupabaseServerClient", () => {
       { name: "session", value: "abc123" },
       { name: "token", value: "xyz" },
     ]);
+  });
+
+  it("cookie getAll filters out cookies with null value", () => {
+    vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("SUPABASE_ANON_KEY", "test-anon-key");
+
+    const request = new Request("http://localhost", {
+      headers: { Cookie: "a=1; b" },
+    });
+    createSupabaseServerClient(request);
+
+    mockParseCookieHeader.mockReturnValueOnce([
+      { name: "a", value: "1" },
+      { name: "b", value: null },
+    ]);
+
+    const cookies = capturedOptions?.cookies.getAll();
+    expect(cookies).toEqual([{ name: "a", value: "1" }]);
   });
 
   it("cookie setAll appends Set-Cookie headers", () => {


### PR DESCRIPTION
## Summary

- `color-mode.tsx` の未テスト 5 コンポーネント/フック（ColorModeIcon, ColorModeButton, LightMode, DarkMode, useColorModeValue）のテスト追加
- `emotion-client.tsx` の `useInjectStyles` テスト追加（StrictMode で injectRef ガードを検証）
- `emotion-client-ssr.test.tsx` を新規作成し SSR 環境での no-op 動作を検証
- `server.ts` の cookie null value フィルタ分岐テスト追加
- `pnpm test:coverage` で全カテゴリ（Stmts / Branch / Funcs / Lines）100% を達成

Closes #6

## Test plan

- [ ] `pnpm test:coverage` で全カテゴリ 100%
- [ ] `pnpm lint` が pass すること
- [ ] `pnpm check-types` が pass すること
- [ ] `pnpm knip` で未使用コード警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only additions/updates; they may only affect CI stability if mocks or environment assumptions differ.
> 
> **Overview**
> Improves web app test coverage by expanding `color-mode.test.tsx` to cover `useColorMode` edge cases (including `forcedTheme`), `toggleColorMode`, `useColorModeValue`, and the `ColorModeIcon`/`ColorModeButton`/`LightMode`/`DarkMode` components with explicit mocks for `next-themes`, Chakra, and icons.
> 
> Adds new tests for `useInjectStyles` in `emotion-client.test.tsx` (including `StrictMode` behavior) and introduces `emotion-client-ssr.test.tsx` to assert `useInjectStyles` is a no-op under SSR (`@vitest-environment node`).
> 
> Extends `supabase/server.test.ts` to validate the `cookies.getAll` path filters out cookies with `null` values by mocking `parseCookieHeader`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29658774c5f487171a2f0b65c5ceada524a157b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->