### PR TITLE
ci: update-external workflow を template-ideas に合わせて置換

### DIFF
--- a/.github/workflows/update-external.yml
+++ b/.github/workflows/update-external.yml
@@ -1,94 +1,109 @@
-name: 外部参照の更新
+name: Update external sources
 
 on:
   schedule:
-    - cron: "0 0 * * 1" # 毎週月曜 0:00 UTC
-  workflow_dispatch: # 手動実行も可能
+    - cron: '0 0 * * *'   # 00:00 UTC = 09:00 JST
+  workflow_dispatch:
+    inputs:
+      target:
+        description: '更新対象 (手動実行時のみ有効。schedule は常に all)'
+        type: choice
+        required: false
+        default: all
+        options:
+          - all
+          - submodule
+          - skill
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: update-external
   cancel-in-progress: false
 
 jobs:
   # --------------------------------------------------
-  # Submodule の更新
-  # Fandhe-AI/actions/submodule-update を利用
+  # submodule 参照の更新 (Fandhe-AI/actions/submodule-update)
   # --------------------------------------------------
-  update-submodules:
-    name: Submodule 更新
+  # 現時点で本リポジトリに .gitmodules は無いが、将来 submodule を
+  # 追加した際にそのまま機能するよう team-hub と同一構成で用意する。
+  submodule:
+    name: Update submodule references
+    if: ${{ github.event_name != 'workflow_dispatch' || contains(fromJSON('["all", "submodule"]'), inputs.target) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      # GITHUB_TOKEN で作成した PR は後続 CI を発火しないため、
-      # CI 発火 + auto-merge を成立させるには App トークンを使う。
-      # owner を指定し、submodule (別リポジトリ) も読めるよう
-      # App インストールスコープまでトークンを広げる
-      # （App は本リポジトリと全 submodule リポジトリにインストールが必要）。
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
+      - name: Checkout
+        # actions/checkout v6.0.3
+        # PAT 未設定時は GITHUB_TOKEN にフォールバック（auto-merge 後の CI 未発火に注意）。
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          app-id: ${{ vars.AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      # workflow_dispatch を main 以外から実行しても常に main 基準で更新を計算する
-      # （base-branch: main へ無関係な差分が混入するのを防ぐ）
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
+          # base-branch が main 固定のため、workflow_dispatch で非 main ブランチから
+          # 起動された場合でも常に main を checkout し、他ブランチのツリー混入を防ぐ。
           ref: main
           submodules: recursive
-          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Update submodules and open PR
-        uses: Fandhe-AI/actions/submodule-update@c80ff94f229f86ba9e08723948c4dee0e1fb66bf # main
+        # Fandhe-AI/actions はタグ未作成のため最新コミット SHA に固定する。
+        uses: Fandhe-AI/actions/submodule-update@c80ff94f229f86ba9e08723948c4dee0e1fb66bf
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
           base-branch: main
-          pr-labels: dependencies
-          auto-merge: ${{ vars.SUBMODULE_AUTO_MERGE }}
+          branch-prefix: chore/submodule-update
+          commit-message: 'chore: submodule を最新に更新'
+          pr-title: 'chore: submodule を最新に更新'
+          pr-labels: 'dependencies,automated'
+          # auto-merge の ON/OFF。未設定 (null/空) を有効と解釈する非対称設計のため、
+          # 未設定時は明示的に 'false' へフォールバックしオプトイン運用とする。
+          auto-merge: ${{ vars.SUBMODULE_AUTO_MERGE || 'false' }}
           auto-merge-allowlist: ${{ vars.SUBMODULE_AUTO_MERGE_ALLOWLIST }}
+          auto-merge-strategy: squash
 
   # --------------------------------------------------
-  # Skills の更新
-  # Fandhe-AI/actions/skills-update を利用
+  # Skills の更新 (Fandhe-AI/actions/skills-update)
   # --------------------------------------------------
-  update-skills:
-    name: Skills 更新
+  skills:
+    name: Update agent skills
+    if: ${{ github.event_name != 'workflow_dispatch' || contains(fromJSON('["all", "skill"]'), inputs.target) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      # owner を指定し、skills の取得元 (Fandhe-AI/agent-*-skills 等の
-      # 別リポジトリ) を読めるよう App インストールスコープまで広げる
-      # （public な取得元は認証不要。private なソースは App のインストールが必要）。
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
+      - name: Checkout
+        # actions/checkout v6.0.3
+        # PAT 未設定時は GITHUB_TOKEN にフォールバック（auto-merge 後の CI 未発火に注意）。
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
-          app-id: ${{ vars.AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      # workflow_dispatch を main 以外から実行しても常に main 基準で更新を計算する
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
+          # base-branch が main 固定のため、workflow_dispatch で非 main ブランチから
+          # 起動された場合でも常に main を checkout し、他ブランチのツリー混入を防ぐ。
           ref: main
-          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        # actions/setup-node v6.4.0。skills-update が使う npx skills のため node を固定する。
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '20'
 
       - name: Update skills and open PR
-        uses: Fandhe-AI/actions/skills-update@c80ff94f229f86ba9e08723948c4dee0e1fb66bf # main
+        # Fandhe-AI/actions はタグ未作成のため最新コミット SHA に固定する。
+        uses: Fandhe-AI/actions/skills-update@c80ff94f229f86ba9e08723948c4dee0e1fb66bf
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN }}
           base-branch: main
-          pr-labels: dependencies
-          auto-merge: ${{ vars.SKILLS_AUTO_MERGE }}
+          branch-prefix: chore/skills-update
+          commit-message: 'chore: エージェントスキルを最新に更新'
+          pr-title: 'chore: エージェントスキルを最新に更新'
+          pr-labels: 'dependencies,automated'
+          # auto-merge の ON/OFF。未設定 (null/空) を有効と解釈する非対称設計のため、
+          # 未設定時は明示的に 'false' へフォールバックしオプトイン運用とする。
+          auto-merge: ${{ vars.SKILLS_AUTO_MERGE || 'false' }}
           auto-merge-allowlist: ${{ vars.SKILLS_AUTO_MERGE_ALLOWLIST }}
+          auto-merge-strategy: squash


### PR DESCRIPTION
## Summary

- `.github/workflows/update-external.yml` を [Fandhe-AI/template-ideas](https://github.com/Fandhe-AI/template-ideas/blob/main/.github/workflows/update-external.yml) の内容に置換
- スケジュールを毎週月曜 → 毎日 09:00 JST (`0 0 * * *`) に変更
- `workflow_dispatch` に `target` (all/submodule/skill) 選択入力を追加し、ジョブごとに `if` で実行制御
- 認証を GitHub App トークン生成方式 → `secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN` のフォールバック方式へ変更
- `actions/checkout` / `actions/setup-node` をコミット SHA で固定
- skills ジョブに Node.js 20 のセットアップを追加
- `branch-prefix` / `commit-message` / `pr-title` の明示指定、`auto-merge` 未設定時の `'false'` フォールバック、`auto-merge-strategy: squash` を追加

## Test plan

- [ ] `workflow_dispatch` で `target: submodule` / `skill` / `all` を手動実行し、対象ジョブのみ起動することを確認
- [ ] PR 作成・auto-merge 動作の確認（必要な secrets/vars 設定後）
- [ ] schedule トリガーで全ジョブが起動することを確認

## Design

- Figma: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how automated PRs are authenticated and when auto-merge runs; missing SUBMODULE_PAT can block follow-up CI on merged dependency PRs.
> 
> **Overview**
> Replaces **`.github/workflows/update-external.yml`** with the **template-ideas** pattern so submodule and agent-skill updates run on a shared schedule and can be triggered selectively.
> 
> The cron moves from **weekly Monday** to **daily 00:00 UTC (09:00 JST)**. Manual runs gain a **`target`** input (`all` / `submodule` / `skill`); each job runs only when the event is scheduled or the chosen target matches. Job IDs are renamed to **`submodule`** and **`skills`**, with concurrency grouped under **`update-external`**.
> 
> **Authentication** drops GitHub App token generation in favor of **`secrets.SUBMODULE_PAT || secrets.GITHUB_TOKEN`** (comments note CI may not fire on auto-merged PRs without a PAT). **`actions/checkout`** and **`actions/setup-node`** are pinned by commit SHA; the skills job adds **Node 20** for `npx skills`.
> 
> PR automation is more explicit: **`branch-prefix`**, commit/PR titles, **`dependencies,automated`** labels, **`auto-merge-strategy: squash`**, and **`auto-merge`** defaulting to **`'false'`** when repo vars are unset (opt-in vs the prior “unset means on” behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bca1d0ecaea498f39af70a5d93d46f1abca34312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->